### PR TITLE
soong: Add ability to build scudo-free 32-bit libc variant.

### DIFF
--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -134,6 +134,9 @@ $(call add_json_list, DeviceSystemSdkVersions,           $(BOARD_SYSTEMSDK_VERSI
 $(call add_json_str,  RecoverySnapshotVersion,           $(RECOVERY_SNAPSHOT_VERSION))
 $(call add_json_list, Platform_systemsdk_versions,       $(PLATFORM_SYSTEMSDK_VERSIONS))
 $(call add_json_bool, Malloc_not_svelte,                 $(call invert_bool,$(filter true,$(MALLOC_SVELTE))))
+$(call add_json_bool, Malloc_not_svelte_libc32,          $(if $(MALLOC_SVELTE_FOR_LIBC32),\
+                                                            $(call invert_bool,$(filter true,$(MALLOC_SVELTE_FOR_LIBC32))),\
+                                                            $(call invert_bool,$(filter true,$(MALLOC_SVELTE)))))
 $(call add_json_bool, Malloc_zero_contents,              $(call invert_bool,$(filter false,$(MALLOC_ZERO_CONTENTS))))
 $(call add_json_bool, Malloc_pattern_fill_contents,      $(MALLOC_PATTERN_FILL_CONTENTS))
 $(call add_json_str,  Override_rs_driver,                $(OVERRIDE_RS_DRIVER))


### PR DESCRIPTION
Targets can switch on this feature by setting
MALLOC_SVELTE_FOR_LIBC32 := true

The default is to build libc32 with scudo enabled.

This fixes camera not working on some legacy devices.

https://review.lineageos.org/c/LineageOS/android_build/+/322579