### PR TITLE
envsetup: Source vendorsetups after running roomservice in lunch

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -781,6 +781,7 @@ function lunch()
         vendor/evolution/build/tools/roomservice.py $product true
         cd - > /dev/null
     fi
+    source_vendorsetup
 
     TARGET_PRODUCT=$product \
     TARGET_BUILD_VARIANT=$variant \


### PR DESCRIPTION
* This will improve CI integration and help devices that have dependencies to repos setting variables in vendorsetups. An example to this is Project Kasumi's GCGOP: It sets the variable GCGOP_VENDOR_DIR to dynamically locate where it's cloned. rosemary depends on it to ship Google Camera GO through it.

Signed-off-by: Beru Hinode <windowz414@1337.lgbt>