### PR TITLE
core: config.mk: Always include lineage sepolicy

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -1257,12 +1257,10 @@ dont_bother_goals := out product-graph
 # consistency with those defined in BoardConfig.mk files.
 include $(BUILD_SYSTEM)/android_soong_config_vars.mk
 
-ifneq ($(LINEAGE_BUILD),)
 ifneq ($(wildcard device/lineage/sepolicy/common/sepolicy.mk),)
 ## We need to be sure the global selinux policies are included
 ## last, to avoid accidental resetting by device configs
 $(eval include device/lineage/sepolicy/common/sepolicy.mk)
-endif
 endif
 
 ifeq ($(CALLED_FROM_SETUP),true)


### PR DESCRIPTION
More information see here:
https://uwu-gl.github.io/2024/07/13/在基于LineageOS的但是没做完全的rom上修复非设备独有树的Sepolicy报错/index/ (Google translate is a good tool lol)